### PR TITLE
Relax servant bounds and use stackage lts-7.8

### DIFF
--- a/fbmessenger-api.cabal
+++ b/fbmessenger-api.cabal
@@ -30,8 +30,8 @@ library
                      , aeson
                      , bytestring
                      , http-client
-                     , servant == 0.7.*
-                     , servant-client == 0.7.*
+                     , servant >= 0.7.0
+                     , servant-client >= 0.7.0
                      , text
                      , transformers
                      , unordered-containers
@@ -55,8 +55,8 @@ executable example
                     ,  http-client-tls
                     ,  fbmessenger-api
                     ,  monad-logger
-                    ,  servant == 0.7.*
-                    ,  servant-server == 0.7.*
+                    ,  servant >= 0.7.0
+                    ,  servant-server >= 0.7.0
                     ,  stm
                     ,  text
                     ,  transformers

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,16 +2,13 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.17
+resolver: lts-7.8
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
- - servant-0.7.1
- - servant-client-0.7.1
- - servant-server-0.7.1
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Would like to use your library for a project of mine where I'm using LTS-7.8 (currently the latest) and GHC 8.0.1. Thought I might as well submit an update.